### PR TITLE
add new Enter param for smooth migration

### DIFF
--- a/src/main/cdp/keyboard.ts
+++ b/src/main/cdp/keyboard.ts
@@ -8,7 +8,8 @@ export interface KeyCodeInformation {
 export const keyDescriptions: Array<KeyCodeInformation> = [
     { key: 'Backspace', chars: '\b', keyCode: 8, code: 'Backspace' },
     { key: 'Tab', chars: '\t', keyCode: 9, code: 'Tab' },
-    { key: 'Enter', chars: '\n', keyCode: 13, code: 'Enter' },
+    { key: '\n', chars: '\n', keyCode: 13, code: 'Enter' }, // wrong key, should be merged with \r once scripts are migrated to use newEnter
+    { key: 'Enter', chars: '\r', keyCode: 13, code: 'Enter' },
     { key: ' ', chars: ' ', keyCode: 32, code: 'Space' },
     { key: '`', chars: '`~', keyCode: 192, code: 'Backquote' },
     { key: '1', chars: '1!¡⁄', keyCode: 49, code: 'Digit1' },

--- a/src/main/cdp/remote-element.ts
+++ b/src/main/cdp/remote-element.ts
@@ -203,6 +203,7 @@ export class RemoteElement extends RemoteObject {
             blur = true,
             parallel = true,
             delay = 0,
+            newEnter = false,
         } = options;
         if (click) {
             await this.click(clickOptions);
@@ -217,7 +218,9 @@ export class RemoteElement extends RemoteObject {
             delay,
             parallel,
         });
-        if (enter) {
+        if (newEnter) {
+            await this.page.inputManager.print('\r');
+        } else if (enter) {
             await this.page.inputManager.print('\n');
         }
         if (blur) {
@@ -599,4 +602,5 @@ export interface TypeTextOptions {
     blur?: boolean;
     parallel?: boolean;
     delay?: number;
+    newEnter?: boolean;
 }

--- a/src/main/engine/actions/Page.input.ts
+++ b/src/main/engine/actions/Page.input.ts
@@ -70,8 +70,10 @@ The exact algorithm is as follows:
     useFocus: boolean = true;
     @params.Boolean()
     useBlur: boolean = true;
-    @params.Boolean()
+    @params.Boolean({ label: 'Use Enter (deprecated)', help: 'Will be removed because wrong key (\\n) is used in the keyboard event. Use Enter instead.' })
     useEnter: boolean = false;
+    @params.Boolean({ label: 'Use Enter' })
+    useNewEnter: boolean = false;
     @params.Boolean()
     maskInput: boolean = false;
     @params.Number({
@@ -118,6 +120,7 @@ The exact algorithm is as follows:
             enter: this.useEnter,
             delay: this.delay,
             parallel: this.delay === 0,
+            newEnter: this.useNewEnter,
         });
         // Retry if input value does not match the requested value
         const { value: actualValue } = await el.getInfo(true);


### PR DESCRIPTION
GH issue: https://github.com/ubio/squad-automation-cloud/issues/338

Due to latest finding of how double enter could result in completely different behaviour of the website, created solution to safely migrate to new Enter param. Once the migration part is finished deprecated Enter param should be removed. Hopefully this change won't result in more changes needed in scripting but at least it won't result in breaking scripts in production if the existing Enter button is fixed. 

Details and videos can be found in the latest comment of a [GH issue](https://github.com/ubio/squad-automation-cloud/issues/338).