### PR TITLE
chore: add capsolver tests

### DIFF
--- a/src/test/cdp/specs/capsolver-chrome-extension.test.ts
+++ b/src/test/cdp/specs/capsolver-chrome-extension.test.ts
@@ -1,0 +1,96 @@
+import assert from 'assert';
+import * as fs from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+
+import { CapsolverChromeExtension } from '../../../main/cdp/capsolver-chrome-extension';
+
+
+describe('CapsolverChromeExtension', () => {
+    let capsolver: CapsolverChromeExtension;
+    const extensionPath = path.join(tmpdir(), 'my-extension-folder');
+    const assetsPath = path.join(extensionPath, 'assets');
+    const configPath = path.join(assetsPath, 'config.json');
+    const apiKey = 'test-api-key';
+
+    before(async () => {
+        await fs.mkdir(assetsPath, { recursive: true });
+    });
+
+    after(async () => {
+        await fs.rm(assetsPath, { recursive: true, force: true });
+    });
+
+    beforeEach(async () => {
+        capsolver = new CapsolverChromeExtension(extensionPath, apiKey);
+
+        const defaultConfig = {
+            apiKey: '',
+            appId: '',
+            useCapsolver: true,
+            manualSolving: false,
+            solvedCallback: 'captchaSolvedCallback',
+            useProxy: false,
+            proxyType: 'http',
+            hostOrIp: '',
+            port: '',
+            proxyLogin: '',
+            proxyPassword: '',
+
+            enabledForBlacklistControl: false,
+            blackUrlList: [],
+
+            enabledForRecaptcha: true,
+            enabledForRecaptchaV3: true,
+            enabledForHCaptcha: true,
+            enabledForFunCaptcha: true,
+            enabledForImageToText: true,
+
+            reCaptchaMode: 'click',
+            hCaptchaMode: 'click',
+
+            reCaptchaDelayTime: 0,
+            hCaptchaDelayTime: 0,
+            textCaptchaDelayTime: 0,
+
+            reCaptchaRepeatTimes: 10,
+            reCaptcha3RepeatTimes: 10,
+            hCaptchaRepeatTimes: 10,
+            funCaptchaRepeatTimes: 10,
+            textCaptchaRepeatTimes: 10,
+
+            textCaptchaSourceAttribute: 'capsolver-image-to-text-source',
+            textCaptchaResultAttribute: 'capsolver-image-to-text-result'
+
+        };
+        await fs.writeFile(configPath, JSON.stringify(defaultConfig, null, 2), { encoding: 'utf8' });
+    });
+
+    afterEach(async () => {
+        await fs.unlink(configPath);
+    });
+
+    describe('addApiKey', () => {
+        it('should add the API key to the config file', async () => {
+            await capsolver.addApiKey();
+
+            const rawData = await fs.readFile(configPath, { encoding: 'utf8' });
+            const jsonData = JSON.parse(rawData);
+
+            assert.equal(jsonData.apiKey, apiKey);
+        });
+    });
+
+    describe('removeApiKey', () => {
+        it('should remove the API key from the config file', async () => {
+            await capsolver.addApiKey();
+
+            await capsolver.removeApiKey();
+
+            const rawData = await fs.readFile(configPath, { encoding: 'utf8' });
+            const jsonData = JSON.parse(rawData);
+
+            assert.equal(jsonData.apiKey, '');
+        });
+    });
+});

--- a/src/test/cdp/specs/capsolver-chrome-extension.test.ts
+++ b/src/test/cdp/specs/capsolver-chrome-extension.test.ts
@@ -79,6 +79,21 @@ describe('CapsolverChromeExtension', () => {
 
             assert.equal(jsonData.apiKey, apiKey);
         });
+
+        it('should simulate 16 m1 workers concurrently adding API key to the same config', async () => {
+
+            const promises: Promise<void>[] = [];
+            for (let i = 0; i < 16; ++i) {
+                promises.push(capsolver.addApiKey());
+            }
+
+            await Promise.all(promises);
+
+            const rawData = await fs.readFile(configPath, { encoding: 'utf8' });
+            const jsonData = JSON.parse(rawData);
+
+            assert.equal(jsonData.apiKey, apiKey);
+        });
     });
 
     describe('removeApiKey', () => {


### PR DESCRIPTION
Cover adding CapSolver api key with tests. One test describes real case scenario with possible concurrent writes to the same config file. Also here are the logs related to the updating API key on production, sometimes JSON.parse fails for unknown reason:

https://grafana.ubio.dev/explore?panes=%7B%22l-x%22:%7B%22datasource%22:%22000000002%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcluster%3D%5C%22ew-prd-01%5C%22%7D%20%7C~%20%5C%22Updating%20api%20key%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000002%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-30m%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1

Just to make sure that API key is present in the config file on every chrome launch there is a check if the api key in the file is different from the env variable. If the error becomes annoying write of the API key could be moved in some general initialisation of drones/workers that happens once during deployment of new version.

Last chunk of the GitHub issue: https://github.com/ubio/squad-automation-cloud/issues/445