### PR TITLE
expose MOBILE_DEVICE_HOSTNAME env var to script

### DIFF
--- a/src/main/engine/ctx.ts
+++ b/src/main/engine/ctx.ts
@@ -106,6 +106,9 @@ export class RuntimeCtx {
         }
     }
 
+    getMobileDeviceHostname() {
+        return process.env.MOBILE_DEVICE_HOSTNAME ?? '';
+    }
 }
 
 export type IntrospectionResult = IntrospectionResultPipe | IntrospectionResultPipeline;


### PR DESCRIPTION
Sort of a workaround since the initial attempt to use --host-resolver-rules chrome arg doesn't work at all.
There will be a separate deployment for each mobile worker to set the corresponding MOBILE_DEVICE_HOSTNAME env variable. 

Here is a PR for the 02 mobile worker: [PR](https://github.com/ubio/infrastructure/pull/167/files)