### PR TITLE
feat: add more robust fetchCurrentPlaywrightPage method

### DIFF
--- a/src/main/engine/services/browser.ts
+++ b/src/main/engine/services/browser.ts
@@ -108,9 +108,23 @@ export class BrowserService extends Browser {
         return this._currentPage;
     }
 
+    /**
+     * @deprecated Use fetchCurrentPlaywrightPage instead. It attempts to set the Playwright current page if it wasn't set previously.
+     */
     getCurrentPlaywrightPage() {
         util.assertPlayback(this.playwright.getCurrentPage(), `No attached Playwright page`);
         return this.playwright.getCurrentPage()!;
+    }
+
+    async fetchCurrentPlaywrightPage() {
+        let currentPage = this.playwright.getCurrentPage();
+
+        if (!currentPage && this._currentPage?.target?.targetId) {
+            await this.playwright.setCurrentPage(this._currentPage?.target.targetId);
+            currentPage = this.playwright.getCurrentPage();
+        }
+        util.assertPlayback(currentPage, `No attached Playwright page`);
+        return currentPage!;
     }
 
     async openNewTab() {


### PR DESCRIPTION
[Logs](https://console.cloud.google.com/logs/query;query=labels.%22k8s-pod%2Fapp%22%3D%22worker%22%0Aseverity%3DERROR%0A--Show%20similar%20entries%0AtextPayload%3D~%22time%3D%2528%5Cd%7B4%7D-%25280%5B1-9%5D%7C1%5B0-2%5D%2529-%25280%5B1-9%5D%7C%5B12%5D%5B0-9%5D%7C3%5B01%5D%2529%2529T%2528%2528%5Cd%7B2%7D%2529:%2528%5Cd%7B2%7D%2529%2528%3F::%2528%5Cd%7B2%7D%2528%3F:%5C.%5Cd*%2529%3F%2529%2529%3F%2528%3F:%2528%5B%2B-%5D%2528%3F:%5Cd%7B2%7D%2529:%3F%2528%3F:%5Cd%7B2%7D%2529%3F%7CZ%2529%3F%2529%2529%20level%3Dwarn%20message%3D%5C%22Failed%20to%20set%20current%20Playwright%20Page%20to%20%2528%5B0-9a-fA-F%5D*%2528%5Ba-fA-F%5D%2B%5B0-9%5D%2B%7C%5B0-9%5D%2B%5Ba-fA-F%5D%2B%2529%5B0-9a-fA-F%5D*%2529%5C%22%20workerId%3D%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20workerTag%3Dmobile%20workerVersion%3D%2528%2528%3F:%5Cd%5B,.%5D%3F%2529*%5Cd%2529%20jobId%3D%2528%5B0-9a-fA-F%5D%7B8%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B12%7D%2529%20executionId%3D%2528%5B0-9a-fA-F%5D%7B8%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B12%7D%2529%20serviceId%3D%2528%5B0-9a-fA-F%5D%7B8%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B12%7D%2529%20clientId%3D%2528%5B0-9a-fA-F%5D%7B8%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B12%7D%2529%20organisationId%3D%2528%5B0-9a-fA-F%5D%7B8%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B4%7D-%5B0-9a-fA-F%5D%7B12%7D%2529%22%0A--End%20of%20show%20similar%20entries;cursorTimestamp=2024-05-24T07:43:07.576768656Z?project=automation-cloud-production) show that setting current Playwright page sometimes fails.

Therefore introducing a more robust method to try setting again when getting current Playwright page and marking old one as deprecated.